### PR TITLE
Zip non .zip files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Zip non `.zip` files by default. This can be overriden by specifying `zip: false` (GitHub Action) or `--no-zip` (Command Line)
+
 ## [0.0.14] - 2022-01-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Options:
   -p, --password <password>   OneReport password
   -r, --reports <glob...>     Glob to the files to publish
   -u, --url <url>             OneReport URL (default: "https://one-report.vercel.app")
-  -z, --zip                   Zip non .zip files (default: true)
+  --no-zip                    Do not zip non .zip files
   -h, --help                  display help for command
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Options:
   -p, --password <password>   OneReport password
   -r, --reports <glob...>     Glob to the files to publish
   -u, --url <url>             OneReport URL (default: "https://one-report.vercel.app")
+  -z, --zip                   Zip non .zip files (default: true)
   -h, --help                  display help for command
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'OneReport URL'
     required: false
     default: 'https://one-report.vercel.app'
+  zip:
+    description: 'If true, compress all non .zip files into a zip file before publishing'
+    required: false
+    default: 'true'
 outputs:
   report-urls:
     description: 'Report URLs'

--- a/action/index.cjs
+++ b/action/index.cjs
@@ -113,11 +113,11 @@ var require_command = __commonJS({
       }
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.issue = exports.issueCommand = void 0
-    var os2 = __importStar(require('os'))
+    var os3 = __importStar(require('os'))
     var utils_1 = require_utils()
     function issueCommand(command, properties, message) {
       const cmd = new Command(command, properties, message)
-      process.stdout.write(cmd.toString() + os2.EOL)
+      process.stdout.write(cmd.toString() + os3.EOL)
     }
     exports.issueCommand = issueCommand
     function issue(name, message = '') {
@@ -220,18 +220,18 @@ var require_file_command = __commonJS({
       }
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.issueCommand = void 0
-    var fs2 = __importStar(require('fs'))
-    var os2 = __importStar(require('os'))
+    var fs3 = __importStar(require('fs'))
+    var os3 = __importStar(require('os'))
     var utils_1 = require_utils()
     function issueCommand(command, message) {
       const filePath = process.env[`GITHUB_${command}`]
       if (!filePath) {
         throw new Error(`Unable to find environment variable for file command ${command}`)
       }
-      if (!fs2.existsSync(filePath)) {
+      if (!fs3.existsSync(filePath)) {
         throw new Error(`Missing file at path: ${filePath}`)
       }
-      fs2.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os2.EOL}`, {
+      fs3.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os3.EOL}`, {
         encoding: 'utf8',
       })
     }
@@ -1306,7 +1306,7 @@ var require_core = __commonJS({
     var command_1 = require_command()
     var file_command_1 = require_file_command()
     var utils_1 = require_utils()
-    var os2 = __importStar(require('os'))
+    var os3 = __importStar(require('os'))
     var path = __importStar(require('path'))
     var oidc_utils_1 = require_oidc_utils()
     var ExitCode
@@ -1320,7 +1320,7 @@ var require_core = __commonJS({
       const filePath = process.env['GITHUB_ENV'] || ''
       if (filePath) {
         const delimiter = '_GitHubActionsFileCommandDelimeter_'
-        const commandValue = `${name}<<${delimiter}${os2.EOL}${convertedVal}${os2.EOL}${delimiter}`
+        const commandValue = `${name}<<${delimiter}${os3.EOL}${convertedVal}${os3.EOL}${delimiter}`
         file_command_1.issueCommand('ENV', commandValue)
       } else {
         command_1.issueCommand('set-env', { name }, convertedVal)
@@ -1370,7 +1370,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``)
     }
     exports.getBooleanInput = getBooleanInput
     function setOutput(name, value) {
-      process.stdout.write(os2.EOL)
+      process.stdout.write(os3.EOL)
       command_1.issueCommand('set-output', { name }, value)
     }
     exports.setOutput = setOutput
@@ -1416,7 +1416,7 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``)
     }
     exports.notice = notice
     function info(message) {
-      process.stdout.write(message + os2.EOL)
+      process.stdout.write(message + os3.EOL)
     }
     exports.info = info
     function startGroup(name) {
@@ -4516,8 +4516,8 @@ var require_pattern = __commonJS({
     }
     exports.endsWithSlashGlobStar = endsWithSlashGlobStar
     function isAffectDepthOfReadingPattern(pattern) {
-      const basename = path.basename(pattern)
-      return endsWithSlashGlobStar(pattern) || isStaticPattern(basename)
+      const basename2 = path.basename(pattern)
+      return endsWithSlashGlobStar(pattern) || isStaticPattern(basename2)
     }
     exports.isAffectDepthOfReadingPattern = isAffectDepthOfReadingPattern
     function expandPatternsWithBraceExpansion(patterns) {
@@ -4739,8 +4739,8 @@ var require_utils4 = __commonJS({
     exports.array = array
     var errno = require_errno()
     exports.errno = errno
-    var fs2 = require_fs()
-    exports.fs = fs2
+    var fs3 = require_fs()
+    exports.fs = fs3
     var path = require_path()
     exports.path = path
     var pattern = require_pattern()
@@ -4939,12 +4939,12 @@ var require_fs2 = __commonJS({
     'use strict'
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.createFileSystemAdapter = exports.FILE_SYSTEM_ADAPTER = void 0
-    var fs2 = require('fs')
+    var fs3 = require('fs')
     exports.FILE_SYSTEM_ADAPTER = {
-      lstat: fs2.lstat,
-      stat: fs2.stat,
-      lstatSync: fs2.lstatSync,
-      statSync: fs2.statSync,
+      lstat: fs3.lstat,
+      stat: fs3.stat,
+      lstatSync: fs3.lstatSync,
+      statSync: fs3.statSync,
     }
     function createFileSystemAdapter(fsMethods) {
       if (fsMethods === void 0) {
@@ -4961,12 +4961,12 @@ var require_settings = __commonJS({
   'node_modules/@nodelib/fs.stat/out/settings.js'(exports) {
     'use strict'
     Object.defineProperty(exports, '__esModule', { value: true })
-    var fs2 = require_fs2()
+    var fs3 = require_fs2()
     var Settings = class {
       constructor(_options = {}) {
         this._options = _options
         this.followSymbolicLink = this._getValue(this._options.followSymbolicLink, true)
-        this.fs = fs2.createFileSystemAdapter(this._options.fs)
+        this.fs = fs3.createFileSystemAdapter(this._options.fs)
         this.markSymbolicLink = this._getValue(this._options.markSymbolicLink, false)
         this.throwErrorOnBrokenSymbolicLink = this._getValue(
           this._options.throwErrorOnBrokenSymbolicLink,
@@ -5134,8 +5134,8 @@ var require_utils5 = __commonJS({
     'use strict'
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.fs = void 0
-    var fs2 = require_fs3()
-    exports.fs = fs2
+    var fs3 = require_fs3()
+    exports.fs = fs3
   },
 })
 
@@ -5330,14 +5330,14 @@ var require_fs4 = __commonJS({
     'use strict'
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.createFileSystemAdapter = exports.FILE_SYSTEM_ADAPTER = void 0
-    var fs2 = require('fs')
+    var fs3 = require('fs')
     exports.FILE_SYSTEM_ADAPTER = {
-      lstat: fs2.lstat,
-      stat: fs2.stat,
-      lstatSync: fs2.lstatSync,
-      statSync: fs2.statSync,
-      readdir: fs2.readdir,
-      readdirSync: fs2.readdirSync,
+      lstat: fs3.lstat,
+      stat: fs3.stat,
+      lstatSync: fs3.lstatSync,
+      statSync: fs3.statSync,
+      readdir: fs3.readdir,
+      readdirSync: fs3.readdirSync,
     }
     function createFileSystemAdapter(fsMethods) {
       if (fsMethods === void 0) {
@@ -5356,12 +5356,12 @@ var require_settings2 = __commonJS({
     Object.defineProperty(exports, '__esModule', { value: true })
     var path = require('path')
     var fsStat = require_out()
-    var fs2 = require_fs4()
+    var fs3 = require_fs4()
     var Settings = class {
       constructor(_options = {}) {
         this._options = _options
         this.followSymbolicLinks = this._getValue(this._options.followSymbolicLinks, false)
-        this.fs = fs2.createFileSystemAdapter(this._options.fs)
+        this.fs = fs3.createFileSystemAdapter(this._options.fs)
         this.pathSegmentSeparator = this._getValue(this._options.pathSegmentSeparator, path.sep)
         this.stats = this._getValue(this._options.stats, false)
         this.throwErrorOnBrokenSymbolicLink = this._getValue(
@@ -6674,16 +6674,16 @@ var require_settings4 = __commonJS({
     'use strict'
     Object.defineProperty(exports, '__esModule', { value: true })
     exports.DEFAULT_FILE_SYSTEM_ADAPTER = void 0
-    var fs2 = require('fs')
-    var os2 = require('os')
-    var CPU_COUNT = Math.max(os2.cpus().length, 1)
+    var fs3 = require('fs')
+    var os3 = require('os')
+    var CPU_COUNT = Math.max(os3.cpus().length, 1)
     exports.DEFAULT_FILE_SYSTEM_ADAPTER = {
-      lstat: fs2.lstat,
-      lstatSync: fs2.lstatSync,
-      stat: fs2.stat,
-      statSync: fs2.statSync,
-      readdir: fs2.readdir,
-      readdirSync: fs2.readdirSync,
+      lstat: fs3.lstat,
+      lstatSync: fs3.lstatSync,
+      stat: fs3.stat,
+      statSync: fs3.statSync,
+      readdir: fs3.readdir,
+      readdirSync: fs3.readdirSync,
     }
     var Settings = class {
       constructor(_options = {}) {
@@ -6796,6 +6796,2114 @@ var require_out4 = __commonJS({
       }
     }
     module2.exports = FastGlob
+  },
+})
+
+// node_modules/adm-zip/util/fileSystem.js
+var require_fileSystem = __commonJS({
+  'node_modules/adm-zip/util/fileSystem.js'(exports) {
+    exports.require = function () {
+      if (typeof process === 'object' && process.versions && process.versions['electron']) {
+        try {
+          const originalFs = require('original-fs')
+          if (Object.keys(originalFs).length > 0) {
+            return originalFs
+          }
+        } catch (e) {}
+      }
+      return require('fs')
+    }
+  },
+})
+
+// node_modules/adm-zip/util/constants.js
+var require_constants4 = __commonJS({
+  'node_modules/adm-zip/util/constants.js'(exports, module2) {
+    module2.exports = {
+      LOCHDR: 30,
+      LOCSIG: 67324752,
+      LOCVER: 4,
+      LOCFLG: 6,
+      LOCHOW: 8,
+      LOCTIM: 10,
+      LOCCRC: 14,
+      LOCSIZ: 18,
+      LOCLEN: 22,
+      LOCNAM: 26,
+      LOCEXT: 28,
+      EXTSIG: 134695760,
+      EXTHDR: 16,
+      EXTCRC: 4,
+      EXTSIZ: 8,
+      EXTLEN: 12,
+      CENHDR: 46,
+      CENSIG: 33639248,
+      CENVEM: 4,
+      CENVER: 6,
+      CENFLG: 8,
+      CENHOW: 10,
+      CENTIM: 12,
+      CENCRC: 16,
+      CENSIZ: 20,
+      CENLEN: 24,
+      CENNAM: 28,
+      CENEXT: 30,
+      CENCOM: 32,
+      CENDSK: 34,
+      CENATT: 36,
+      CENATX: 38,
+      CENOFF: 42,
+      ENDHDR: 22,
+      ENDSIG: 101010256,
+      ENDSUB: 8,
+      ENDTOT: 10,
+      ENDSIZ: 12,
+      ENDOFF: 16,
+      ENDCOM: 20,
+      END64HDR: 20,
+      END64SIG: 117853008,
+      END64START: 4,
+      END64OFF: 8,
+      END64NUMDISKS: 16,
+      ZIP64SIG: 101075792,
+      ZIP64HDR: 56,
+      ZIP64LEAD: 12,
+      ZIP64SIZE: 4,
+      ZIP64VEM: 12,
+      ZIP64VER: 14,
+      ZIP64DSK: 16,
+      ZIP64DSKDIR: 20,
+      ZIP64SUB: 24,
+      ZIP64TOT: 32,
+      ZIP64SIZB: 40,
+      ZIP64OFF: 48,
+      ZIP64EXTRA: 56,
+      STORED: 0,
+      SHRUNK: 1,
+      REDUCED1: 2,
+      REDUCED2: 3,
+      REDUCED3: 4,
+      REDUCED4: 5,
+      IMPLODED: 6,
+      DEFLATED: 8,
+      ENHANCED_DEFLATED: 9,
+      PKWARE: 10,
+      BZIP2: 12,
+      LZMA: 14,
+      IBM_TERSE: 18,
+      IBM_LZ77: 19,
+      AES_ENCRYPT: 99,
+      FLG_ENC: 1,
+      FLG_COMP1: 2,
+      FLG_COMP2: 4,
+      FLG_DESC: 8,
+      FLG_ENH: 16,
+      FLG_PATCH: 32,
+      FLG_STR: 64,
+      FLG_EFS: 2048,
+      FLG_MSK: 4096,
+      FILE: 2,
+      BUFFER: 1,
+      NONE: 0,
+      EF_ID: 0,
+      EF_SIZE: 2,
+      ID_ZIP64: 1,
+      ID_AVINFO: 7,
+      ID_PFS: 8,
+      ID_OS2: 9,
+      ID_NTFS: 10,
+      ID_OPENVMS: 12,
+      ID_UNIX: 13,
+      ID_FORK: 14,
+      ID_PATCH: 15,
+      ID_X509_PKCS7: 20,
+      ID_X509_CERTID_F: 21,
+      ID_X509_CERTID_C: 22,
+      ID_STRONGENC: 23,
+      ID_RECORD_MGT: 24,
+      ID_X509_PKCS7_RL: 25,
+      ID_IBM1: 101,
+      ID_IBM2: 102,
+      ID_POSZIP: 18064,
+      EF_ZIP64_OR_32: 4294967295,
+      EF_ZIP64_OR_16: 65535,
+      EF_ZIP64_SUNCOMP: 0,
+      EF_ZIP64_SCOMP: 8,
+      EF_ZIP64_RHO: 16,
+      EF_ZIP64_DSN: 24,
+    }
+  },
+})
+
+// node_modules/adm-zip/util/utils.js
+var require_utils6 = __commonJS({
+  'node_modules/adm-zip/util/utils.js'(exports, module2) {
+    var fsystem = require_fileSystem().require()
+    var pth = require('path')
+    var Constants = require_constants4()
+    var isWin = typeof process === 'object' && process.platform === 'win32'
+    var is_Obj = (obj) => obj && typeof obj === 'object'
+    var crcTable = new Uint32Array(256).map((t, c) => {
+      for (let k = 0; k < 8; k++) {
+        if ((c & 1) !== 0) {
+          c = 3988292384 ^ (c >>> 1)
+        } else {
+          c >>>= 1
+        }
+      }
+      return c >>> 0
+    })
+    function Utils(opts) {
+      this.sep = pth.sep
+      this.fs = fsystem
+      if (is_Obj(opts)) {
+        if (is_Obj(opts.fs) && typeof opts.fs.statSync === 'function') {
+          this.fs = opts.fs
+        }
+      }
+    }
+    module2.exports = Utils
+    Utils.prototype.makeDir = function (folder) {
+      const self = this
+      function mkdirSync(fpath) {
+        let resolvedPath = fpath.split(self.sep)[0]
+        fpath.split(self.sep).forEach(function (name) {
+          if (!name || name.substr(-1, 1) === ':') return
+          resolvedPath += self.sep + name
+          var stat
+          try {
+            stat = self.fs.statSync(resolvedPath)
+          } catch (e) {
+            self.fs.mkdirSync(resolvedPath)
+          }
+          if (stat && stat.isFile()) throw Errors.FILE_IN_THE_WAY.replace('%s', resolvedPath)
+        })
+      }
+      mkdirSync(folder)
+    }
+    Utils.prototype.writeFileTo = function (path, content, overwrite, attr) {
+      const self = this
+      if (self.fs.existsSync(path)) {
+        if (!overwrite) return false
+        var stat = self.fs.statSync(path)
+        if (stat.isDirectory()) {
+          return false
+        }
+      }
+      var folder = pth.dirname(path)
+      if (!self.fs.existsSync(folder)) {
+        self.makeDir(folder)
+      }
+      var fd
+      try {
+        fd = self.fs.openSync(path, 'w', 438)
+      } catch (e) {
+        self.fs.chmodSync(path, 438)
+        fd = self.fs.openSync(path, 'w', 438)
+      }
+      if (fd) {
+        try {
+          self.fs.writeSync(fd, content, 0, content.length, 0)
+        } finally {
+          self.fs.closeSync(fd)
+        }
+      }
+      self.fs.chmodSync(path, attr || 438)
+      return true
+    }
+    Utils.prototype.writeFileToAsync = function (path, content, overwrite, attr, callback) {
+      if (typeof attr === 'function') {
+        callback = attr
+        attr = void 0
+      }
+      const self = this
+      self.fs.exists(path, function (exist) {
+        if (exist && !overwrite) return callback(false)
+        self.fs.stat(path, function (err, stat) {
+          if (exist && stat.isDirectory()) {
+            return callback(false)
+          }
+          var folder = pth.dirname(path)
+          self.fs.exists(folder, function (exists) {
+            if (!exists) self.makeDir(folder)
+            self.fs.open(path, 'w', 438, function (err2, fd) {
+              if (err2) {
+                self.fs.chmod(path, 438, function () {
+                  self.fs.open(path, 'w', 438, function (err3, fd2) {
+                    self.fs.write(fd2, content, 0, content.length, 0, function () {
+                      self.fs.close(fd2, function () {
+                        self.fs.chmod(path, attr || 438, function () {
+                          callback(true)
+                        })
+                      })
+                    })
+                  })
+                })
+              } else if (fd) {
+                self.fs.write(fd, content, 0, content.length, 0, function () {
+                  self.fs.close(fd, function () {
+                    self.fs.chmod(path, attr || 438, function () {
+                      callback(true)
+                    })
+                  })
+                })
+              } else {
+                self.fs.chmod(path, attr || 438, function () {
+                  callback(true)
+                })
+              }
+            })
+          })
+        })
+      })
+    }
+    Utils.prototype.findFiles = function (path) {
+      const self = this
+      function findSync(dir, pattern, recursive) {
+        if (typeof pattern === 'boolean') {
+          recursive = pattern
+          pattern = void 0
+        }
+        let files = []
+        self.fs.readdirSync(dir).forEach(function (file) {
+          var path2 = pth.join(dir, file)
+          if (self.fs.statSync(path2).isDirectory() && recursive)
+            files = files.concat(findSync(path2, pattern, recursive))
+          if (!pattern || pattern.test(path2)) {
+            files.push(
+              pth.normalize(path2) + (self.fs.statSync(path2).isDirectory() ? self.sep : '')
+            )
+          }
+        })
+        return files
+      }
+      return findSync(path, void 0, true)
+    }
+    Utils.prototype.getAttributes = function () {}
+    Utils.prototype.setAttributes = function () {}
+    Utils.crc32update = function (crc, byte) {
+      return crcTable[(crc ^ byte) & 255] ^ (crc >>> 8)
+    }
+    Utils.crc32 = function (buf) {
+      if (typeof buf === 'string') {
+        buf = Buffer.from(buf, 'utf8')
+      }
+      if (!crcTable.length) genCRCTable()
+      let len = buf.length
+      let crc = ~0
+      for (let off = 0; off < len; ) crc = Utils.crc32update(crc, buf[off++])
+      return ~crc >>> 0
+    }
+    Utils.methodToString = function (method) {
+      switch (method) {
+        case Constants.STORED:
+          return 'STORED (' + method + ')'
+        case Constants.DEFLATED:
+          return 'DEFLATED (' + method + ')'
+        default:
+          return 'UNSUPPORTED (' + method + ')'
+      }
+    }
+    Utils.canonical = function (path) {
+      if (!path) return ''
+      var safeSuffix = pth.posix.normalize('/' + path.split('\\').join('/'))
+      return pth.join('.', safeSuffix)
+    }
+    Utils.sanitize = function (prefix, name) {
+      prefix = pth.resolve(pth.normalize(prefix))
+      var parts = name.split('/')
+      for (var i = 0, l = parts.length; i < l; i++) {
+        var path = pth.normalize(pth.join(prefix, parts.slice(i, l).join(pth.sep)))
+        if (path.indexOf(prefix) === 0) {
+          return path
+        }
+      }
+      return pth.normalize(pth.join(prefix, pth.basename(name)))
+    }
+    Utils.toBuffer = function toBuffer(input) {
+      if (Buffer.isBuffer(input)) {
+        return input
+      } else if (input instanceof Uint8Array) {
+        return Buffer.from(input)
+      } else {
+        return typeof input === 'string' ? Buffer.from(input, 'utf8') : Buffer.alloc(0)
+      }
+    }
+    Utils.readBigUInt64LE = function (buffer, index) {
+      var slice = Buffer.from(buffer.slice(index, index + 8))
+      slice.swap64()
+      return parseInt(`0x${slice.toString('hex')}`)
+    }
+    Utils.isWin = isWin
+    Utils.crcTable = crcTable
+  },
+})
+
+// node_modules/adm-zip/util/errors.js
+var require_errors = __commonJS({
+  'node_modules/adm-zip/util/errors.js'(exports, module2) {
+    module2.exports = {
+      INVALID_LOC: 'Invalid LOC header (bad signature)',
+      INVALID_CEN: 'Invalid CEN header (bad signature)',
+      INVALID_END: 'Invalid END header (bad signature)',
+      NO_DATA: 'Nothing to decompress',
+      BAD_CRC: 'CRC32 checksum failed',
+      FILE_IN_THE_WAY: 'There is a file in the way: %s',
+      UNKNOWN_METHOD: 'Invalid/unsupported compression method',
+      AVAIL_DATA: 'inflate::Available inflate data did not terminate',
+      INVALID_DISTANCE:
+        'inflate::Invalid literal/length or distance code in fixed or dynamic block',
+      TO_MANY_CODES: 'inflate::Dynamic block code description: too many length or distance codes',
+      INVALID_REPEAT_LEN:
+        'inflate::Dynamic block code description: repeat more than specified lengths',
+      INVALID_REPEAT_FIRST:
+        'inflate::Dynamic block code description: repeat lengths with no first length',
+      INCOMPLETE_CODES: 'inflate::Dynamic block code description: code lengths codes incomplete',
+      INVALID_DYN_DISTANCE:
+        'inflate::Dynamic block code description: invalid distance code lengths',
+      INVALID_CODES_LEN:
+        'inflate::Dynamic block code description: invalid literal/length code lengths',
+      INVALID_STORE_BLOCK: "inflate::Stored block length did not match one's complement",
+      INVALID_BLOCK_TYPE: 'inflate::Invalid block type (type == 3)',
+      CANT_EXTRACT_FILE: 'Could not extract the file',
+      CANT_OVERRIDE: 'Target file already exists',
+      NO_ZIP: 'No zip file was loaded',
+      NO_ENTRY: "Entry doesn't exist",
+      DIRECTORY_CONTENT_ERROR: 'A directory cannot have content',
+      FILE_NOT_FOUND: 'File not found: %s',
+      NOT_IMPLEMENTED: 'Not implemented',
+      INVALID_FILENAME: 'Invalid filename',
+      INVALID_FORMAT: 'Invalid or unsupported zip format. No END header found',
+    }
+  },
+})
+
+// node_modules/adm-zip/util/fattr.js
+var require_fattr = __commonJS({
+  'node_modules/adm-zip/util/fattr.js'(exports, module2) {
+    var fs3 = require_fileSystem().require()
+    var pth = require('path')
+    fs3.existsSync = fs3.existsSync || pth.existsSync
+    module2.exports = function (path) {
+      var _path = path || '',
+        _obj = newAttr(),
+        _stat = null
+      function newAttr() {
+        return {
+          directory: false,
+          readonly: false,
+          hidden: false,
+          executable: false,
+          mtime: 0,
+          atime: 0,
+        }
+      }
+      if (_path && fs3.existsSync(_path)) {
+        _stat = fs3.statSync(_path)
+        _obj.directory = _stat.isDirectory()
+        _obj.mtime = _stat.mtime
+        _obj.atime = _stat.atime
+        _obj.executable = (73 & _stat.mode) !== 0
+        _obj.readonly = (128 & _stat.mode) === 0
+        _obj.hidden = pth.basename(_path)[0] === '.'
+      } else {
+        console.warn('Invalid path: ' + _path)
+      }
+      return {
+        get directory() {
+          return _obj.directory
+        },
+        get readOnly() {
+          return _obj.readonly
+        },
+        get hidden() {
+          return _obj.hidden
+        },
+        get mtime() {
+          return _obj.mtime
+        },
+        get atime() {
+          return _obj.atime
+        },
+        get executable() {
+          return _obj.executable
+        },
+        decodeAttributes: function () {},
+        encodeAttributes: function () {},
+        toJSON: function () {
+          return {
+            path: _path,
+            isDirectory: _obj.directory,
+            isReadOnly: _obj.readonly,
+            isHidden: _obj.hidden,
+            isExecutable: _obj.executable,
+            mTime: _obj.mtime,
+            aTime: _obj.atime,
+          }
+        },
+        toString: function () {
+          return JSON.stringify(this.toJSON(), null, '	')
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/util/index.js
+var require_util = __commonJS({
+  'node_modules/adm-zip/util/index.js'(exports, module2) {
+    module2.exports = require_utils6()
+    module2.exports.Constants = require_constants4()
+    module2.exports.Errors = require_errors()
+    module2.exports.FileAttr = require_fattr()
+  },
+})
+
+// node_modules/adm-zip/headers/entryHeader.js
+var require_entryHeader = __commonJS({
+  'node_modules/adm-zip/headers/entryHeader.js'(exports, module2) {
+    var Utils = require_util()
+    var Constants = Utils.Constants
+    module2.exports = function () {
+      var _verMade = 20,
+        _version = 10,
+        _flags = 0,
+        _method = 0,
+        _time = 0,
+        _crc = 0,
+        _compressedSize = 0,
+        _size = 0,
+        _fnameLen = 0,
+        _extraLen = 0,
+        _comLen = 0,
+        _diskStart = 0,
+        _inattr = 0,
+        _attr = 0,
+        _offset = 0
+      _verMade |= Utils.isWin ? 2560 : 768
+      _flags |= Constants.FLG_EFS
+      var _dataHeader = {}
+      function setTime(val) {
+        val = new Date(val)
+        _time =
+          (((val.getFullYear() - 1980) & 127) << 25) |
+          ((val.getMonth() + 1) << 21) |
+          (val.getDate() << 16) |
+          (val.getHours() << 11) |
+          (val.getMinutes() << 5) |
+          (val.getSeconds() >> 1)
+      }
+      setTime(+new Date())
+      return {
+        get made() {
+          return _verMade
+        },
+        set made(val) {
+          _verMade = val
+        },
+        get version() {
+          return _version
+        },
+        set version(val) {
+          _version = val
+        },
+        get flags() {
+          return _flags
+        },
+        set flags(val) {
+          _flags = val
+        },
+        get method() {
+          return _method
+        },
+        set method(val) {
+          switch (val) {
+            case Constants.STORED:
+              this.version = 10
+            case Constants.DEFLATED:
+            default:
+              this.version = 20
+          }
+          _method = val
+        },
+        get time() {
+          return new Date(
+            ((_time >> 25) & 127) + 1980,
+            ((_time >> 21) & 15) - 1,
+            (_time >> 16) & 31,
+            (_time >> 11) & 31,
+            (_time >> 5) & 63,
+            (_time & 31) << 1
+          )
+        },
+        set time(val) {
+          setTime(val)
+        },
+        get crc() {
+          return _crc
+        },
+        set crc(val) {
+          _crc = Math.max(0, val) >>> 0
+        },
+        get compressedSize() {
+          return _compressedSize
+        },
+        set compressedSize(val) {
+          _compressedSize = Math.max(0, val) >>> 0
+        },
+        get size() {
+          return _size
+        },
+        set size(val) {
+          _size = Math.max(0, val) >>> 0
+        },
+        get fileNameLength() {
+          return _fnameLen
+        },
+        set fileNameLength(val) {
+          _fnameLen = val
+        },
+        get extraLength() {
+          return _extraLen
+        },
+        set extraLength(val) {
+          _extraLen = val
+        },
+        get commentLength() {
+          return _comLen
+        },
+        set commentLength(val) {
+          _comLen = val
+        },
+        get diskNumStart() {
+          return _diskStart
+        },
+        set diskNumStart(val) {
+          _diskStart = Math.max(0, val) >>> 0
+        },
+        get inAttr() {
+          return _inattr
+        },
+        set inAttr(val) {
+          _inattr = Math.max(0, val) >>> 0
+        },
+        get attr() {
+          return _attr
+        },
+        set attr(val) {
+          _attr = Math.max(0, val) >>> 0
+        },
+        get fileAttr() {
+          return _attr ? (((_attr >>> 0) | 0) >> 16) & 4095 : 0
+        },
+        get offset() {
+          return _offset
+        },
+        set offset(val) {
+          _offset = Math.max(0, val) >>> 0
+        },
+        get encripted() {
+          return (_flags & 1) === 1
+        },
+        get entryHeaderSize() {
+          return Constants.CENHDR + _fnameLen + _extraLen + _comLen
+        },
+        get realDataOffset() {
+          return _offset + Constants.LOCHDR + _dataHeader.fnameLen + _dataHeader.extraLen
+        },
+        get dataHeader() {
+          return _dataHeader
+        },
+        loadDataHeaderFromBinary: function (input) {
+          var data = input.slice(_offset, _offset + Constants.LOCHDR)
+          if (data.readUInt32LE(0) !== Constants.LOCSIG) {
+            throw new Error(Utils.Errors.INVALID_LOC)
+          }
+          _dataHeader = {
+            version: data.readUInt16LE(Constants.LOCVER),
+            flags: data.readUInt16LE(Constants.LOCFLG),
+            method: data.readUInt16LE(Constants.LOCHOW),
+            time: data.readUInt32LE(Constants.LOCTIM),
+            crc: data.readUInt32LE(Constants.LOCCRC),
+            compressedSize: data.readUInt32LE(Constants.LOCSIZ),
+            size: data.readUInt32LE(Constants.LOCLEN),
+            fnameLen: data.readUInt16LE(Constants.LOCNAM),
+            extraLen: data.readUInt16LE(Constants.LOCEXT),
+          }
+        },
+        loadFromBinary: function (data) {
+          if (data.length !== Constants.CENHDR || data.readUInt32LE(0) !== Constants.CENSIG) {
+            throw new Error(Utils.Errors.INVALID_CEN)
+          }
+          _verMade = data.readUInt16LE(Constants.CENVEM)
+          _version = data.readUInt16LE(Constants.CENVER)
+          _flags = data.readUInt16LE(Constants.CENFLG)
+          _method = data.readUInt16LE(Constants.CENHOW)
+          _time = data.readUInt32LE(Constants.CENTIM)
+          _crc = data.readUInt32LE(Constants.CENCRC)
+          _compressedSize = data.readUInt32LE(Constants.CENSIZ)
+          _size = data.readUInt32LE(Constants.CENLEN)
+          _fnameLen = data.readUInt16LE(Constants.CENNAM)
+          _extraLen = data.readUInt16LE(Constants.CENEXT)
+          _comLen = data.readUInt16LE(Constants.CENCOM)
+          _diskStart = data.readUInt16LE(Constants.CENDSK)
+          _inattr = data.readUInt16LE(Constants.CENATT)
+          _attr = data.readUInt32LE(Constants.CENATX)
+          _offset = data.readUInt32LE(Constants.CENOFF)
+        },
+        dataHeaderToBinary: function () {
+          var data = Buffer.alloc(Constants.LOCHDR)
+          data.writeUInt32LE(Constants.LOCSIG, 0)
+          data.writeUInt16LE(_version, Constants.LOCVER)
+          data.writeUInt16LE(_flags, Constants.LOCFLG)
+          data.writeUInt16LE(_method, Constants.LOCHOW)
+          data.writeUInt32LE(_time, Constants.LOCTIM)
+          data.writeUInt32LE(_crc, Constants.LOCCRC)
+          data.writeUInt32LE(_compressedSize, Constants.LOCSIZ)
+          data.writeUInt32LE(_size, Constants.LOCLEN)
+          data.writeUInt16LE(_fnameLen, Constants.LOCNAM)
+          data.writeUInt16LE(_extraLen, Constants.LOCEXT)
+          return data
+        },
+        entryHeaderToBinary: function () {
+          var data = Buffer.alloc(Constants.CENHDR + _fnameLen + _extraLen + _comLen)
+          data.writeUInt32LE(Constants.CENSIG, 0)
+          data.writeUInt16LE(_verMade, Constants.CENVEM)
+          data.writeUInt16LE(_version, Constants.CENVER)
+          data.writeUInt16LE(_flags, Constants.CENFLG)
+          data.writeUInt16LE(_method, Constants.CENHOW)
+          data.writeUInt32LE(_time, Constants.CENTIM)
+          data.writeUInt32LE(_crc, Constants.CENCRC)
+          data.writeUInt32LE(_compressedSize, Constants.CENSIZ)
+          data.writeUInt32LE(_size, Constants.CENLEN)
+          data.writeUInt16LE(_fnameLen, Constants.CENNAM)
+          data.writeUInt16LE(_extraLen, Constants.CENEXT)
+          data.writeUInt16LE(_comLen, Constants.CENCOM)
+          data.writeUInt16LE(_diskStart, Constants.CENDSK)
+          data.writeUInt16LE(_inattr, Constants.CENATT)
+          data.writeUInt32LE(_attr, Constants.CENATX)
+          data.writeUInt32LE(_offset, Constants.CENOFF)
+          data.fill(0, Constants.CENHDR)
+          return data
+        },
+        toJSON: function () {
+          const bytes = function (nr) {
+            return nr + ' bytes'
+          }
+          return {
+            made: _verMade,
+            version: _version,
+            flags: _flags,
+            method: Utils.methodToString(_method),
+            time: this.time,
+            crc: '0x' + _crc.toString(16).toUpperCase(),
+            compressedSize: bytes(_compressedSize),
+            size: bytes(_size),
+            fileNameLength: bytes(_fnameLen),
+            extraLength: bytes(_extraLen),
+            commentLength: bytes(_comLen),
+            diskNumStart: _diskStart,
+            inAttr: _inattr,
+            attr: _attr,
+            offset: _offset,
+            entryHeaderSize: bytes(Constants.CENHDR + _fnameLen + _extraLen + _comLen),
+          }
+        },
+        toString: function () {
+          return JSON.stringify(this.toJSON(), null, '	')
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/headers/mainHeader.js
+var require_mainHeader = __commonJS({
+  'node_modules/adm-zip/headers/mainHeader.js'(exports, module2) {
+    var Utils = require_util()
+    var Constants = Utils.Constants
+    module2.exports = function () {
+      var _volumeEntries = 0,
+        _totalEntries = 0,
+        _size = 0,
+        _offset = 0,
+        _commentLength = 0
+      return {
+        get diskEntries() {
+          return _volumeEntries
+        },
+        set diskEntries(val) {
+          _volumeEntries = _totalEntries = val
+        },
+        get totalEntries() {
+          return _totalEntries
+        },
+        set totalEntries(val) {
+          _totalEntries = _volumeEntries = val
+        },
+        get size() {
+          return _size
+        },
+        set size(val) {
+          _size = val
+        },
+        get offset() {
+          return _offset
+        },
+        set offset(val) {
+          _offset = val
+        },
+        get commentLength() {
+          return _commentLength
+        },
+        set commentLength(val) {
+          _commentLength = val
+        },
+        get mainHeaderSize() {
+          return Constants.ENDHDR + _commentLength
+        },
+        loadFromBinary: function (data) {
+          if (
+            (data.length !== Constants.ENDHDR || data.readUInt32LE(0) !== Constants.ENDSIG) &&
+            (data.length < Constants.ZIP64HDR || data.readUInt32LE(0) !== Constants.ZIP64SIG)
+          ) {
+            throw new Error(Utils.Errors.INVALID_END)
+          }
+          if (data.readUInt32LE(0) === Constants.ENDSIG) {
+            _volumeEntries = data.readUInt16LE(Constants.ENDSUB)
+            _totalEntries = data.readUInt16LE(Constants.ENDTOT)
+            _size = data.readUInt32LE(Constants.ENDSIZ)
+            _offset = data.readUInt32LE(Constants.ENDOFF)
+            _commentLength = data.readUInt16LE(Constants.ENDCOM)
+          } else {
+            _volumeEntries = Utils.readBigUInt64LE(data, Constants.ZIP64SUB)
+            _totalEntries = Utils.readBigUInt64LE(data, Constants.ZIP64TOT)
+            _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZ)
+            _offset = Utils.readBigUInt64LE(data, Constants.ZIP64OFF)
+            _commentLength = 0
+          }
+        },
+        toBinary: function () {
+          var b = Buffer.alloc(Constants.ENDHDR + _commentLength)
+          b.writeUInt32LE(Constants.ENDSIG, 0)
+          b.writeUInt32LE(0, 4)
+          b.writeUInt16LE(_volumeEntries, Constants.ENDSUB)
+          b.writeUInt16LE(_totalEntries, Constants.ENDTOT)
+          b.writeUInt32LE(_size, Constants.ENDSIZ)
+          b.writeUInt32LE(_offset, Constants.ENDOFF)
+          b.writeUInt16LE(_commentLength, Constants.ENDCOM)
+          b.fill(' ', Constants.ENDHDR)
+          return b
+        },
+        toJSON: function () {
+          const offset = function (nr, len) {
+            let offs = nr.toString(16).toUpperCase()
+            while (offs.length < len) offs = '0' + offs
+            return '0x' + offs
+          }
+          return {
+            diskEntries: _volumeEntries,
+            totalEntries: _totalEntries,
+            size: _size + ' bytes',
+            offset: offset(_offset, 4),
+            commentLength: _commentLength,
+          }
+        },
+        toString: function () {
+          return JSON.stringify(this.toJSON(), null, '	')
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/headers/index.js
+var require_headers = __commonJS({
+  'node_modules/adm-zip/headers/index.js'(exports) {
+    exports.EntryHeader = require_entryHeader()
+    exports.MainHeader = require_mainHeader()
+  },
+})
+
+// node_modules/adm-zip/methods/deflater.js
+var require_deflater = __commonJS({
+  'node_modules/adm-zip/methods/deflater.js'(exports, module2) {
+    module2.exports = function (inbuf) {
+      var zlib = require('zlib')
+      var opts = { chunkSize: (parseInt(inbuf.length / 1024) + 1) * 1024 }
+      return {
+        deflate: function () {
+          return zlib.deflateRawSync(inbuf, opts)
+        },
+        deflateAsync: function (callback) {
+          var tmp = zlib.createDeflateRaw(opts),
+            parts = [],
+            total = 0
+          tmp.on('data', function (data) {
+            parts.push(data)
+            total += data.length
+          })
+          tmp.on('end', function () {
+            var buf = Buffer.alloc(total),
+              written = 0
+            buf.fill(0)
+            for (var i = 0; i < parts.length; i++) {
+              var part = parts[i]
+              part.copy(buf, written)
+              written += part.length
+            }
+            callback && callback(buf)
+          })
+          tmp.end(inbuf)
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/methods/inflater.js
+var require_inflater = __commonJS({
+  'node_modules/adm-zip/methods/inflater.js'(exports, module2) {
+    module2.exports = function (inbuf) {
+      var zlib = require('zlib')
+      return {
+        inflate: function () {
+          return zlib.inflateRawSync(inbuf)
+        },
+        inflateAsync: function (callback) {
+          var tmp = zlib.createInflateRaw(),
+            parts = [],
+            total = 0
+          tmp.on('data', function (data) {
+            parts.push(data)
+            total += data.length
+          })
+          tmp.on('end', function () {
+            var buf = Buffer.alloc(total),
+              written = 0
+            buf.fill(0)
+            for (var i = 0; i < parts.length; i++) {
+              var part = parts[i]
+              part.copy(buf, written)
+              written += part.length
+            }
+            callback && callback(buf)
+          })
+          tmp.end(inbuf)
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/methods/zipcrypto.js
+var require_zipcrypto = __commonJS({
+  'node_modules/adm-zip/methods/zipcrypto.js'(exports, module2) {
+    'use strict'
+    var { randomFillSync } = require('crypto')
+    var crctable = new Uint32Array(256).map((t, crc) => {
+      for (let j = 0; j < 8; j++) {
+        if ((crc & 1) !== 0) {
+          crc = (crc >>> 1) ^ 3988292384
+        } else {
+          crc >>>= 1
+        }
+      }
+      return crc >>> 0
+    })
+    var uMul = (a, b) => Math.imul(a, b) >>> 0
+    var crc32update = (pCrc32, bval) => {
+      return crctable[(pCrc32 ^ bval) & 255] ^ (pCrc32 >>> 8)
+    }
+    var genSalt = () => {
+      if (typeof randomFillSync === 'function') {
+        return randomFillSync(Buffer.alloc(12))
+      } else {
+        return genSalt.node()
+      }
+    }
+    genSalt.node = () => {
+      const salt = Buffer.alloc(12)
+      const len = salt.length
+      for (let i = 0; i < len; i++) salt[i] = (Math.random() * 256) & 255
+      return salt
+    }
+    var config = {
+      genSalt,
+    }
+    function Initkeys(pw) {
+      const pass = Buffer.isBuffer(pw) ? pw : Buffer.from(pw)
+      this.keys = new Uint32Array([305419896, 591751049, 878082192])
+      for (let i = 0; i < pass.length; i++) {
+        this.updateKeys(pass[i])
+      }
+    }
+    Initkeys.prototype.updateKeys = function (byteValue) {
+      const keys = this.keys
+      keys[0] = crc32update(keys[0], byteValue)
+      keys[1] += keys[0] & 255
+      keys[1] = uMul(keys[1], 134775813) + 1
+      keys[2] = crc32update(keys[2], keys[1] >>> 24)
+      return byteValue
+    }
+    Initkeys.prototype.next = function () {
+      const k = (this.keys[2] | 2) >>> 0
+      return (uMul(k, k ^ 1) >> 8) & 255
+    }
+    function make_decrypter(pwd) {
+      const keys = new Initkeys(pwd)
+      return function (data) {
+        const result = Buffer.alloc(data.length)
+        let pos = 0
+        for (let c of data) {
+          result[pos++] = keys.updateKeys(c ^ keys.next())
+        }
+        return result
+      }
+    }
+    function make_encrypter(pwd) {
+      const keys = new Initkeys(pwd)
+      return function (data, result, pos = 0) {
+        if (!result) result = Buffer.alloc(data.length)
+        for (let c of data) {
+          const k = keys.next()
+          result[pos++] = c ^ k
+          keys.updateKeys(c)
+        }
+        return result
+      }
+    }
+    function decrypt(data, header, pwd) {
+      if (!data || !Buffer.isBuffer(data) || data.length < 12) {
+        return Buffer.alloc(0)
+      }
+      const decrypter = make_decrypter(pwd)
+      const salt = decrypter(data.slice(0, 12))
+      if (salt[11] !== header.crc >>> 24) {
+        throw 'ADM-ZIP: Wrong Password'
+      }
+      return decrypter(data.slice(12))
+    }
+    function _salter(data) {
+      if (Buffer.isBuffer(data) && data.length >= 12) {
+        config.genSalt = function () {
+          return data.slice(0, 12)
+        }
+      } else if (data === 'node') {
+        config.genSalt = genSalt.node
+      } else {
+        config.genSalt = genSalt
+      }
+    }
+    function encrypt(data, header, pwd, oldlike = false) {
+      if (data == null) data = Buffer.alloc(0)
+      if (!Buffer.isBuffer(data)) data = Buffer.from(data.toString())
+      const encrypter = make_encrypter(pwd)
+      const salt = config.genSalt()
+      salt[11] = (header.crc >>> 24) & 255
+      if (oldlike) salt[10] = (header.crc >>> 16) & 255
+      const result = Buffer.alloc(data.length + 12)
+      encrypter(salt, result)
+      return encrypter(data, result, 12)
+    }
+    module2.exports = { decrypt, encrypt, _salter }
+  },
+})
+
+// node_modules/adm-zip/methods/index.js
+var require_methods = __commonJS({
+  'node_modules/adm-zip/methods/index.js'(exports) {
+    exports.Deflater = require_deflater()
+    exports.Inflater = require_inflater()
+    exports.ZipCrypto = require_zipcrypto()
+  },
+})
+
+// node_modules/adm-zip/zipEntry.js
+var require_zipEntry = __commonJS({
+  'node_modules/adm-zip/zipEntry.js'(exports, module2) {
+    var Utils = require_util()
+    var Headers = require_headers()
+    var Constants = Utils.Constants
+    var Methods = require_methods()
+    module2.exports = function (input) {
+      var _entryHeader = new Headers.EntryHeader(),
+        _entryName = Buffer.alloc(0),
+        _comment = Buffer.alloc(0),
+        _isDirectory = false,
+        uncompressedData = null,
+        _extra = Buffer.alloc(0)
+      function getCompressedDataFromZip() {
+        if (!input || !Buffer.isBuffer(input)) {
+          return Buffer.alloc(0)
+        }
+        _entryHeader.loadDataHeaderFromBinary(input)
+        return input.slice(
+          _entryHeader.realDataOffset,
+          _entryHeader.realDataOffset + _entryHeader.compressedSize
+        )
+      }
+      function crc32OK(data) {
+        if ((_entryHeader.flags & 8) !== 8) {
+          if (Utils.crc32(data) !== _entryHeader.dataHeader.crc) {
+            return false
+          }
+        } else {
+        }
+        return true
+      }
+      function decompress(async, callback, pass) {
+        if (typeof callback === 'undefined' && typeof async === 'string') {
+          pass = async
+          async = void 0
+        }
+        if (_isDirectory) {
+          if (async && callback) {
+            callback(Buffer.alloc(0), Utils.Errors.DIRECTORY_CONTENT_ERROR)
+          }
+          return Buffer.alloc(0)
+        }
+        var compressedData = getCompressedDataFromZip()
+        if (compressedData.length === 0) {
+          if (async && callback) callback(compressedData)
+          return compressedData
+        }
+        if (_entryHeader.encripted) {
+          if (typeof pass !== 'string' && !Buffer.isBuffer(pass)) {
+            throw new Error('ADM-ZIP: Incompatible password parameter')
+          }
+          compressedData = Methods.ZipCrypto.decrypt(compressedData, _entryHeader, pass)
+        }
+        var data = Buffer.alloc(_entryHeader.size)
+        switch (_entryHeader.method) {
+          case Utils.Constants.STORED:
+            compressedData.copy(data)
+            if (!crc32OK(data)) {
+              if (async && callback) callback(data, Utils.Errors.BAD_CRC)
+              throw new Error(Utils.Errors.BAD_CRC)
+            } else {
+              if (async && callback) callback(data)
+              return data
+            }
+          case Utils.Constants.DEFLATED:
+            var inflater = new Methods.Inflater(compressedData)
+            if (!async) {
+              const result = inflater.inflate(data)
+              result.copy(data, 0)
+              if (!crc32OK(data)) {
+                throw new Error(Utils.Errors.BAD_CRC + ' ' + _entryName.toString())
+              }
+              return data
+            } else {
+              inflater.inflateAsync(function (result) {
+                result.copy(result, 0)
+                if (callback) {
+                  if (!crc32OK(result)) {
+                    callback(result, Utils.Errors.BAD_CRC)
+                  } else {
+                    callback(result)
+                  }
+                }
+              })
+            }
+            break
+          default:
+            if (async && callback) callback(Buffer.alloc(0), Utils.Errors.UNKNOWN_METHOD)
+            throw new Error(Utils.Errors.UNKNOWN_METHOD)
+        }
+      }
+      function compress(async, callback) {
+        if ((!uncompressedData || !uncompressedData.length) && Buffer.isBuffer(input)) {
+          if (async && callback) callback(getCompressedDataFromZip())
+          return getCompressedDataFromZip()
+        }
+        if (uncompressedData.length && !_isDirectory) {
+          var compressedData
+          switch (_entryHeader.method) {
+            case Utils.Constants.STORED:
+              _entryHeader.compressedSize = _entryHeader.size
+              compressedData = Buffer.alloc(uncompressedData.length)
+              uncompressedData.copy(compressedData)
+              if (async && callback) callback(compressedData)
+              return compressedData
+            default:
+            case Utils.Constants.DEFLATED:
+              var deflater = new Methods.Deflater(uncompressedData)
+              if (!async) {
+                var deflated = deflater.deflate()
+                _entryHeader.compressedSize = deflated.length
+                return deflated
+              } else {
+                deflater.deflateAsync(function (data) {
+                  compressedData = Buffer.alloc(data.length)
+                  _entryHeader.compressedSize = data.length
+                  data.copy(compressedData)
+                  callback && callback(compressedData)
+                })
+              }
+              deflater = null
+              break
+          }
+        } else if (async && callback) {
+          callback(Buffer.alloc(0))
+        } else {
+          return Buffer.alloc(0)
+        }
+      }
+      function readUInt64LE(buffer, offset) {
+        return (buffer.readUInt32LE(offset + 4) << 4) + buffer.readUInt32LE(offset)
+      }
+      function parseExtra(data) {
+        var offset = 0
+        var signature, size, part
+        while (offset < data.length) {
+          signature = data.readUInt16LE(offset)
+          offset += 2
+          size = data.readUInt16LE(offset)
+          offset += 2
+          part = data.slice(offset, offset + size)
+          offset += size
+          if (Constants.ID_ZIP64 === signature) {
+            parseZip64ExtendedInformation(part)
+          }
+        }
+      }
+      function parseZip64ExtendedInformation(data) {
+        var size, compressedSize, offset, diskNumStart
+        if (data.length >= Constants.EF_ZIP64_SCOMP) {
+          size = readUInt64LE(data, Constants.EF_ZIP64_SUNCOMP)
+          if (_entryHeader.size === Constants.EF_ZIP64_OR_32) {
+            _entryHeader.size = size
+          }
+        }
+        if (data.length >= Constants.EF_ZIP64_RHO) {
+          compressedSize = readUInt64LE(data, Constants.EF_ZIP64_SCOMP)
+          if (_entryHeader.compressedSize === Constants.EF_ZIP64_OR_32) {
+            _entryHeader.compressedSize = compressedSize
+          }
+        }
+        if (data.length >= Constants.EF_ZIP64_DSN) {
+          offset = readUInt64LE(data, Constants.EF_ZIP64_RHO)
+          if (_entryHeader.offset === Constants.EF_ZIP64_OR_32) {
+            _entryHeader.offset = offset
+          }
+        }
+        if (data.length >= Constants.EF_ZIP64_DSN + 4) {
+          diskNumStart = data.readUInt32LE(Constants.EF_ZIP64_DSN)
+          if (_entryHeader.diskNumStart === Constants.EF_ZIP64_OR_16) {
+            _entryHeader.diskNumStart = diskNumStart
+          }
+        }
+      }
+      return {
+        get entryName() {
+          return _entryName.toString()
+        },
+        get rawEntryName() {
+          return _entryName
+        },
+        set entryName(val) {
+          _entryName = Utils.toBuffer(val)
+          var lastChar = _entryName[_entryName.length - 1]
+          _isDirectory = lastChar === 47 || lastChar === 92
+          _entryHeader.fileNameLength = _entryName.length
+        },
+        get extra() {
+          return _extra
+        },
+        set extra(val) {
+          _extra = val
+          _entryHeader.extraLength = val.length
+          parseExtra(val)
+        },
+        get comment() {
+          return _comment.toString()
+        },
+        set comment(val) {
+          _comment = Utils.toBuffer(val)
+          _entryHeader.commentLength = _comment.length
+        },
+        get name() {
+          var n = _entryName.toString()
+          return _isDirectory
+            ? n
+                .substr(n.length - 1)
+                .split('/')
+                .pop()
+            : n.split('/').pop()
+        },
+        get isDirectory() {
+          return _isDirectory
+        },
+        getCompressedData: function () {
+          return compress(false, null)
+        },
+        getCompressedDataAsync: function (callback) {
+          compress(true, callback)
+        },
+        setData: function (value) {
+          uncompressedData = Utils.toBuffer(value)
+          if (!_isDirectory && uncompressedData.length) {
+            _entryHeader.size = uncompressedData.length
+            _entryHeader.method = Utils.Constants.DEFLATED
+            _entryHeader.crc = Utils.crc32(value)
+            _entryHeader.changed = true
+          } else {
+            _entryHeader.method = Utils.Constants.STORED
+          }
+        },
+        getData: function (pass) {
+          if (_entryHeader.changed) {
+            return uncompressedData
+          } else {
+            return decompress(false, null, pass)
+          }
+        },
+        getDataAsync: function (callback, pass) {
+          if (_entryHeader.changed) {
+            callback(uncompressedData)
+          } else {
+            decompress(true, callback, pass)
+          }
+        },
+        set attr(attr) {
+          _entryHeader.attr = attr
+        },
+        get attr() {
+          return _entryHeader.attr
+        },
+        set header(data) {
+          _entryHeader.loadFromBinary(data)
+        },
+        get header() {
+          return _entryHeader
+        },
+        packHeader: function () {
+          var header = _entryHeader.entryHeaderToBinary()
+          var addpos = Utils.Constants.CENHDR
+          _entryName.copy(header, addpos)
+          addpos += _entryName.length
+          if (_entryHeader.extraLength) {
+            _extra.copy(header, addpos)
+            addpos += _entryHeader.extraLength
+          }
+          if (_entryHeader.commentLength) {
+            _comment.copy(header, addpos)
+          }
+          return header
+        },
+        toJSON: function () {
+          const bytes = function (nr) {
+            return '<' + ((nr && nr.length + ' bytes buffer') || 'null') + '>'
+          }
+          return {
+            entryName: this.entryName,
+            name: this.name,
+            comment: this.comment,
+            isDirectory: this.isDirectory,
+            header: _entryHeader.toJSON(),
+            compressedData: bytes(input),
+            data: bytes(uncompressedData),
+          }
+        },
+        toString: function () {
+          return JSON.stringify(this.toJSON(), null, '	')
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/zipFile.js
+var require_zipFile = __commonJS({
+  'node_modules/adm-zip/zipFile.js'(exports, module2) {
+    var ZipEntry = require_zipEntry()
+    var Headers = require_headers()
+    var Utils = require_util()
+    module2.exports = function (inBuffer, options) {
+      var entryList = [],
+        entryTable = {},
+        _comment = Buffer.alloc(0),
+        mainHeader = new Headers.MainHeader(),
+        loadedEntries = false
+      const opts = Object.assign(/* @__PURE__ */ Object.create(null), options)
+      const { noSort } = opts
+      if (inBuffer) {
+        readMainHeader(opts.readEntries)
+      } else {
+        loadedEntries = true
+      }
+      function iterateEntries(callback) {
+        const totalEntries = mainHeader.diskEntries
+        let index = mainHeader.offset
+        for (let i = 0; i < totalEntries; i++) {
+          let tmp = index
+          const entry = new ZipEntry(inBuffer)
+          entry.header = inBuffer.slice(tmp, (tmp += Utils.Constants.CENHDR))
+          entry.entryName = inBuffer.slice(tmp, (tmp += entry.header.fileNameLength))
+          index += entry.header.entryHeaderSize
+          callback(entry)
+        }
+      }
+      function readEntries() {
+        loadedEntries = true
+        entryTable = {}
+        entryList = new Array(mainHeader.diskEntries)
+        var index = mainHeader.offset
+        for (var i = 0; i < entryList.length; i++) {
+          var tmp = index,
+            entry = new ZipEntry(inBuffer)
+          entry.header = inBuffer.slice(tmp, (tmp += Utils.Constants.CENHDR))
+          entry.entryName = inBuffer.slice(tmp, (tmp += entry.header.fileNameLength))
+          if (entry.header.extraLength) {
+            entry.extra = inBuffer.slice(tmp, (tmp += entry.header.extraLength))
+          }
+          if (entry.header.commentLength)
+            entry.comment = inBuffer.slice(tmp, tmp + entry.header.commentLength)
+          index += entry.header.entryHeaderSize
+          entryList[i] = entry
+          entryTable[entry.entryName] = entry
+        }
+      }
+      function readMainHeader(readNow) {
+        var i = inBuffer.length - Utils.Constants.ENDHDR,
+          max = Math.max(0, i - 65535),
+          n = max,
+          endStart = inBuffer.length,
+          endOffset = -1,
+          commentEnd = 0
+        for (i; i >= n; i--) {
+          if (inBuffer[i] !== 80) continue
+          if (inBuffer.readUInt32LE(i) === Utils.Constants.ENDSIG) {
+            endOffset = i
+            commentEnd = i
+            endStart = i + Utils.Constants.ENDHDR
+            n = i - Utils.Constants.END64HDR
+            continue
+          }
+          if (inBuffer.readUInt32LE(i) === Utils.Constants.END64SIG) {
+            n = max
+            continue
+          }
+          if (inBuffer.readUInt32LE(i) === Utils.Constants.ZIP64SIG) {
+            endOffset = i
+            endStart =
+              i +
+              Utils.readBigUInt64LE(inBuffer, i + Utils.Constants.ZIP64SIZE) +
+              Utils.Constants.ZIP64LEAD
+            break
+          }
+        }
+        if (!~endOffset) throw new Error(Utils.Errors.INVALID_FORMAT)
+        mainHeader.loadFromBinary(inBuffer.slice(endOffset, endStart))
+        if (mainHeader.commentLength) {
+          _comment = inBuffer.slice(commentEnd + Utils.Constants.ENDHDR)
+        }
+        if (readNow) readEntries()
+      }
+      function sortEntries() {
+        if (entryList.length > 1 && !noSort) {
+          entryList.sort((a, b) =>
+            a.entryName.toLowerCase().localeCompare(b.entryName.toLowerCase())
+          )
+        }
+      }
+      return {
+        get entries() {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          return entryList
+        },
+        get comment() {
+          return _comment.toString()
+        },
+        set comment(val) {
+          _comment = Utils.toBuffer(val)
+          mainHeader.commentLength = _comment.length
+        },
+        getEntryCount: function () {
+          if (!loadedEntries) {
+            return mainHeader.diskEntries
+          }
+          return entryList.length
+        },
+        forEach: function (callback) {
+          if (!loadedEntries) {
+            iterateEntries(callback)
+            return
+          }
+          entryList.forEach(callback)
+        },
+        getEntry: function (entryName) {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          return entryTable[entryName] || null
+        },
+        setEntry: function (entry) {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          entryList.push(entry)
+          entryTable[entry.entryName] = entry
+          mainHeader.totalEntries = entryList.length
+        },
+        deleteEntry: function (entryName) {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          var entry = entryTable[entryName]
+          if (entry && entry.isDirectory) {
+            var _self = this
+            this.getEntryChildren(entry).forEach(function (child) {
+              if (child.entryName !== entryName) {
+                _self.deleteEntry(child.entryName)
+              }
+            })
+          }
+          entryList.splice(entryList.indexOf(entry), 1)
+          delete entryTable[entryName]
+          mainHeader.totalEntries = entryList.length
+        },
+        getEntryChildren: function (entry) {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          if (entry && entry.isDirectory) {
+            const list = []
+            const name = entry.entryName
+            const len = name.length
+            entryList.forEach(function (zipEntry) {
+              if (zipEntry.entryName.substr(0, len) === name) {
+                list.push(zipEntry)
+              }
+            })
+            return list
+          }
+          return []
+        },
+        compressToBuffer: function () {
+          if (!loadedEntries) {
+            readEntries()
+          }
+          sortEntries()
+          const dataBlock = []
+          const entryHeaders = []
+          let totalSize = 0
+          let dindex = 0
+          mainHeader.size = 0
+          mainHeader.offset = 0
+          for (const entry of entryList) {
+            const compressedData = entry.getCompressedData()
+            entry.header.offset = dindex
+            const dataHeader = entry.header.dataHeaderToBinary()
+            const entryNameLen = entry.rawEntryName.length
+            const postHeader = Buffer.alloc(entryNameLen + entry.extra.length)
+            entry.rawEntryName.copy(postHeader, 0)
+            postHeader.copy(entry.extra, entryNameLen)
+            const dataLength = dataHeader.length + postHeader.length + compressedData.length
+            dindex += dataLength
+            dataBlock.push(dataHeader)
+            dataBlock.push(postHeader)
+            dataBlock.push(compressedData)
+            const entryHeader = entry.packHeader()
+            entryHeaders.push(entryHeader)
+            mainHeader.size += entryHeader.length
+            totalSize += dataLength + entryHeader.length
+          }
+          totalSize += mainHeader.mainHeaderSize
+          mainHeader.offset = dindex
+          dindex = 0
+          const outBuffer = Buffer.alloc(totalSize)
+          for (const content of dataBlock) {
+            content.copy(outBuffer, dindex)
+            dindex += content.length
+          }
+          for (const content of entryHeaders) {
+            content.copy(outBuffer, dindex)
+            dindex += content.length
+          }
+          const mh = mainHeader.toBinary()
+          if (_comment) {
+            _comment.copy(mh, Utils.Constants.ENDHDR)
+          }
+          mh.copy(outBuffer, dindex)
+          return outBuffer
+        },
+        toAsyncBuffer: function (onSuccess, onFail, onItemStart, onItemEnd) {
+          try {
+            if (!loadedEntries) {
+              readEntries()
+            }
+            sortEntries()
+            const dataBlock = []
+            const entryHeaders = []
+            let totalSize = 0
+            let dindex = 0
+            mainHeader.size = 0
+            mainHeader.offset = 0
+            const compress2Buffer = function (entryLists) {
+              if (entryLists.length) {
+                const entry = entryLists.pop()
+                const name = entry.entryName + entry.extra.toString()
+                if (onItemStart) onItemStart(name)
+                entry.getCompressedDataAsync(function (compressedData) {
+                  if (onItemEnd) onItemEnd(name)
+                  entry.header.offset = dindex
+                  const dataHeader = entry.header.dataHeaderToBinary()
+                  const postHeader = Buffer.alloc(name.length, name)
+                  const dataLength = dataHeader.length + postHeader.length + compressedData.length
+                  dindex += dataLength
+                  dataBlock.push(dataHeader)
+                  dataBlock.push(postHeader)
+                  dataBlock.push(compressedData)
+                  const entryHeader = entry.packHeader()
+                  entryHeaders.push(entryHeader)
+                  mainHeader.size += entryHeader.length
+                  totalSize += dataLength + entryHeader.length
+                  compress2Buffer(entryLists)
+                })
+              } else {
+                totalSize += mainHeader.mainHeaderSize
+                mainHeader.offset = dindex
+                dindex = 0
+                const outBuffer = Buffer.alloc(totalSize)
+                dataBlock.forEach(function (content) {
+                  content.copy(outBuffer, dindex)
+                  dindex += content.length
+                })
+                entryHeaders.forEach(function (content) {
+                  content.copy(outBuffer, dindex)
+                  dindex += content.length
+                })
+                const mh = mainHeader.toBinary()
+                if (_comment) {
+                  _comment.copy(mh, Utils.Constants.ENDHDR)
+                }
+                mh.copy(outBuffer, dindex)
+                onSuccess(outBuffer)
+              }
+            }
+            compress2Buffer(entryList)
+          } catch (e) {
+            onFail(e)
+          }
+        },
+      }
+    }
+  },
+})
+
+// node_modules/adm-zip/adm-zip.js
+var require_adm_zip = __commonJS({
+  'node_modules/adm-zip/adm-zip.js'(exports, module2) {
+    var Utils = require_util()
+    var pth = require('path')
+    var ZipEntry = require_zipEntry()
+    var ZipFile = require_zipFile()
+    var get_Bool = (val, def) => (typeof val === 'boolean' ? val : def)
+    var get_Str = (val, def) => (typeof val === 'string' ? val : def)
+    var defaultOptions = {
+      noSort: false,
+      readEntries: false,
+      method: Utils.Constants.NONE,
+      fs: null,
+    }
+    module2.exports = function (input, options) {
+      let inBuffer = null
+      const opts = Object.assign(/* @__PURE__ */ Object.create(null), defaultOptions)
+      if (input && typeof input === 'object') {
+        if (!(input instanceof Uint8Array)) {
+          Object.assign(opts, input)
+          input = opts.input ? opts.input : void 0
+          if (opts.input) delete opts.input
+        }
+        if (Buffer.isBuffer(input)) {
+          inBuffer = input
+          opts.method = Utils.Constants.BUFFER
+          input = void 0
+        }
+      }
+      Object.assign(opts, options)
+      const filetools = new Utils(opts)
+      if (input && typeof input === 'string') {
+        if (filetools.fs.existsSync(input)) {
+          opts.method = Utils.Constants.FILE
+          opts.filename = input
+          inBuffer = filetools.fs.readFileSync(input)
+        } else {
+          throw new Error(Utils.Errors.INVALID_FILENAME)
+        }
+      }
+      const _zip = new ZipFile(inBuffer, opts)
+      const { canonical, sanitize } = Utils
+      function getEntry(entry) {
+        if (entry && _zip) {
+          var item
+          if (typeof entry === 'string') item = _zip.getEntry(entry)
+          if (
+            typeof entry === 'object' &&
+            typeof entry.entryName !== 'undefined' &&
+            typeof entry.header !== 'undefined'
+          )
+            item = _zip.getEntry(entry.entryName)
+          if (item) {
+            return item
+          }
+        }
+        return null
+      }
+      function fixPath(zipPath) {
+        const { join: join2, normalize, sep: sep2 } = pth.posix
+        return join2('.', normalize(sep2 + zipPath.split('\\').join(sep2) + sep2))
+      }
+      return {
+        readFile: function (entry, pass) {
+          var item = getEntry(entry)
+          return (item && item.getData(pass)) || null
+        },
+        readFileAsync: function (entry, callback) {
+          var item = getEntry(entry)
+          if (item) {
+            item.getDataAsync(callback)
+          } else {
+            callback(null, 'getEntry failed for:' + entry)
+          }
+        },
+        readAsText: function (entry, encoding) {
+          var item = getEntry(entry)
+          if (item) {
+            var data = item.getData()
+            if (data && data.length) {
+              return data.toString(encoding || 'utf8')
+            }
+          }
+          return ''
+        },
+        readAsTextAsync: function (entry, callback, encoding) {
+          var item = getEntry(entry)
+          if (item) {
+            item.getDataAsync(function (data, err) {
+              if (err) {
+                callback(data, err)
+                return
+              }
+              if (data && data.length) {
+                callback(data.toString(encoding || 'utf8'))
+              } else {
+                callback('')
+              }
+            })
+          } else {
+            callback('')
+          }
+        },
+        deleteFile: function (entry) {
+          var item = getEntry(entry)
+          if (item) {
+            _zip.deleteEntry(item.entryName)
+          }
+        },
+        addZipComment: function (comment) {
+          _zip.comment = comment
+        },
+        getZipComment: function () {
+          return _zip.comment || ''
+        },
+        addZipEntryComment: function (entry, comment) {
+          var item = getEntry(entry)
+          if (item) {
+            item.comment = comment
+          }
+        },
+        getZipEntryComment: function (entry) {
+          var item = getEntry(entry)
+          if (item) {
+            return item.comment || ''
+          }
+          return ''
+        },
+        updateFile: function (entry, content) {
+          var item = getEntry(entry)
+          if (item) {
+            item.setData(content)
+          }
+        },
+        addLocalFile: function (localPath, zipPath, zipName, comment) {
+          if (filetools.fs.existsSync(localPath)) {
+            zipPath = zipPath ? fixPath(zipPath) : ''
+            var p = localPath.split('\\').join('/').split('/').pop()
+            zipPath += zipName ? zipName : p
+            const _attr = filetools.fs.statSync(localPath)
+            this.addFile(zipPath, filetools.fs.readFileSync(localPath), comment, _attr)
+          } else {
+            throw new Error(Utils.Errors.FILE_NOT_FOUND.replace('%s', localPath))
+          }
+        },
+        addLocalFolder: function (localPath, zipPath, filter) {
+          if (filter instanceof RegExp) {
+            filter = (function (rx) {
+              return function (filename) {
+                return rx.test(filename)
+              }
+            })(filter)
+          } else if (typeof filter !== 'function') {
+            filter = function () {
+              return true
+            }
+          }
+          zipPath = zipPath ? fixPath(zipPath) : ''
+          localPath = pth.normalize(localPath)
+          if (filetools.fs.existsSync(localPath)) {
+            const items = filetools.findFiles(localPath)
+            const self = this
+            if (items.length) {
+              items.forEach(function (filepath) {
+                var p = pth.relative(localPath, filepath).split('\\').join('/')
+                if (filter(p)) {
+                  var stats = filetools.fs.statSync(filepath)
+                  if (stats.isFile()) {
+                    self.addFile(zipPath + p, filetools.fs.readFileSync(filepath), '', stats)
+                  } else {
+                    self.addFile(zipPath + p + '/', Buffer.alloc(0), '', stats)
+                  }
+                }
+              })
+            }
+          } else {
+            throw new Error(Utils.Errors.FILE_NOT_FOUND.replace('%s', localPath))
+          }
+        },
+        addLocalFolderAsync: function (localPath, callback, zipPath, filter) {
+          if (filter instanceof RegExp) {
+            filter = (function (rx) {
+              return function (filename) {
+                return rx.test(filename)
+              }
+            })(filter)
+          } else if (typeof filter !== 'function') {
+            filter = function () {
+              return true
+            }
+          }
+          zipPath = zipPath ? fixPath(zipPath) : ''
+          localPath = pth.normalize(localPath)
+          var self = this
+          filetools.fs.open(localPath, 'r', function (err) {
+            if (err && err.code === 'ENOENT') {
+              callback(void 0, Utils.Errors.FILE_NOT_FOUND.replace('%s', localPath))
+            } else if (err) {
+              callback(void 0, err)
+            } else {
+              var items = filetools.findFiles(localPath)
+              var i = -1
+              var next = function () {
+                i += 1
+                if (i < items.length) {
+                  var filepath = items[i]
+                  var p = pth.relative(localPath, filepath).split('\\').join('/')
+                  p = p
+                    .normalize('NFD')
+                    .replace(/[\u0300-\u036f]/g, '')
+                    .replace(/[^\x20-\x7E]/g, '')
+                  if (filter(p)) {
+                    filetools.fs.stat(filepath, function (er0, stats) {
+                      if (er0) callback(void 0, er0)
+                      if (stats.isFile()) {
+                        filetools.fs.readFile(filepath, function (er1, data) {
+                          if (er1) {
+                            callback(void 0, er1)
+                          } else {
+                            self.addFile(zipPath + p, data, '', stats)
+                            next()
+                          }
+                        })
+                      } else {
+                        self.addFile(zipPath + p + '/', Buffer.alloc(0), '', stats)
+                        next()
+                      }
+                    })
+                  } else {
+                    next()
+                  }
+                } else {
+                  callback(true, void 0)
+                }
+              }
+              next()
+            }
+          })
+        },
+        addLocalFolderPromise: function (localPath, props) {
+          return new Promise((resolve, reject) => {
+            const { filter, zipPath } = Object.assign({}, props)
+            this.addLocalFolderAsync(
+              localPath,
+              (done, err) => {
+                if (err) reject(err)
+                if (done) resolve(this)
+              },
+              zipPath,
+              filter
+            )
+          })
+        },
+        addFile: function (entryName, content, comment, attr) {
+          let entry = getEntry(entryName)
+          const update = entry != null
+          if (!update) {
+            entry = new ZipEntry()
+            entry.entryName = entryName
+          }
+          entry.comment = comment || ''
+          const isStat = typeof attr === 'object' && attr instanceof filetools.fs.Stats
+          if (isStat) {
+            entry.header.time = attr.mtime
+          }
+          var fileattr = entry.isDirectory ? 16 : 0
+          if (!Utils.isWin) {
+            let unix = entry.isDirectory ? 16384 : 32768
+            if (isStat) {
+              unix |= 4095 & attr.mode
+            } else if (typeof attr === 'number') {
+              unix |= 4095 & attr
+            } else {
+              unix |= entry.isDirectory ? 493 : 420
+            }
+            fileattr = (fileattr | (unix << 16)) >>> 0
+          }
+          entry.attr = fileattr
+          entry.setData(content)
+          if (!update) _zip.setEntry(entry)
+        },
+        getEntries: function () {
+          return _zip ? _zip.entries : []
+        },
+        getEntry: function (name) {
+          return getEntry(name)
+        },
+        getEntryCount: function () {
+          return _zip.getEntryCount()
+        },
+        forEach: function (callback) {
+          return _zip.forEach(callback)
+        },
+        extractEntryTo: function (
+          entry,
+          targetPath,
+          maintainEntryPath,
+          overwrite,
+          keepOriginalPermission,
+          outFileName
+        ) {
+          overwrite = get_Bool(overwrite, false)
+          keepOriginalPermission = get_Bool(keepOriginalPermission, false)
+          maintainEntryPath = get_Bool(maintainEntryPath, true)
+          outFileName = get_Str(outFileName, get_Str(keepOriginalPermission, void 0))
+          var item = getEntry(entry)
+          if (!item) {
+            throw new Error(Utils.Errors.NO_ENTRY)
+          }
+          var entryName = canonical(item.entryName)
+          var target = sanitize(
+            targetPath,
+            outFileName && !item.isDirectory
+              ? outFileName
+              : maintainEntryPath
+              ? entryName
+              : pth.basename(entryName)
+          )
+          if (item.isDirectory) {
+            var children = _zip.getEntryChildren(item)
+            children.forEach(function (child) {
+              if (child.isDirectory) return
+              var content2 = child.getData()
+              if (!content2) {
+                throw new Error(Utils.Errors.CANT_EXTRACT_FILE)
+              }
+              var name = canonical(child.entryName)
+              var childName = sanitize(targetPath, maintainEntryPath ? name : pth.basename(name))
+              const fileAttr2 = keepOriginalPermission ? child.header.fileAttr : void 0
+              filetools.writeFileTo(childName, content2, overwrite, fileAttr2)
+            })
+            return true
+          }
+          var content = item.getData()
+          if (!content) throw new Error(Utils.Errors.CANT_EXTRACT_FILE)
+          if (filetools.fs.existsSync(target) && !overwrite) {
+            throw new Error(Utils.Errors.CANT_OVERRIDE)
+          }
+          const fileAttr = keepOriginalPermission ? entry.header.fileAttr : void 0
+          filetools.writeFileTo(target, content, overwrite, fileAttr)
+          return true
+        },
+        test: function (pass) {
+          if (!_zip) {
+            return false
+          }
+          for (var entry in _zip.entries) {
+            try {
+              if (entry.isDirectory) {
+                continue
+              }
+              var content = _zip.entries[entry].getData(pass)
+              if (!content) {
+                return false
+              }
+            } catch (err) {
+              return false
+            }
+          }
+          return true
+        },
+        extractAllTo: function (targetPath, overwrite, keepOriginalPermission, pass) {
+          overwrite = get_Bool(overwrite, false)
+          pass = get_Str(keepOriginalPermission, pass)
+          keepOriginalPermission = get_Bool(keepOriginalPermission, false)
+          if (!_zip) {
+            throw new Error(Utils.Errors.NO_ZIP)
+          }
+          _zip.entries.forEach(function (entry) {
+            var entryName = sanitize(targetPath, canonical(entry.entryName.toString()))
+            if (entry.isDirectory) {
+              filetools.makeDir(entryName)
+              return
+            }
+            var content = entry.getData(pass)
+            if (!content) {
+              throw new Error(Utils.Errors.CANT_EXTRACT_FILE)
+            }
+            const fileAttr = keepOriginalPermission ? entry.header.fileAttr : void 0
+            filetools.writeFileTo(entryName, content, overwrite, fileAttr)
+            try {
+              filetools.fs.utimesSync(entryName, entry.header.time, entry.header.time)
+            } catch (err) {
+              throw new Error(Utils.Errors.CANT_EXTRACT_FILE)
+            }
+          })
+        },
+        extractAllToAsync: function (targetPath, overwrite, keepOriginalPermission, callback) {
+          if (!callback) {
+            callback = function () {}
+          }
+          overwrite = get_Bool(overwrite, false)
+          if (typeof keepOriginalPermission === 'function' && !callback)
+            callback = keepOriginalPermission
+          keepOriginalPermission = get_Bool(keepOriginalPermission, false)
+          if (!_zip) {
+            callback(new Error(Utils.Errors.NO_ZIP))
+            return
+          }
+          targetPath = pth.resolve(targetPath)
+          const getPath = (entry) =>
+            sanitize(targetPath, pth.normalize(canonical(entry.entryName.toString())))
+          const getError = (msg, file) => new Error(msg + ': "' + file + '"')
+          const dirEntries = []
+          const fileEntries = /* @__PURE__ */ new Set()
+          _zip.entries.forEach((e) => {
+            if (e.isDirectory) {
+              dirEntries.push(e)
+            } else {
+              fileEntries.add(e)
+            }
+          })
+          for (const entry of dirEntries) {
+            const dirPath = getPath(entry)
+            const dirAttr = keepOriginalPermission ? entry.header.fileAttr : void 0
+            try {
+              filetools.makeDir(dirPath)
+              if (dirAttr) filetools.fs.chmodSync(dirPath, dirAttr)
+              filetools.fs.utimesSync(dirPath, entry.header.time, entry.header.time)
+            } catch (er) {
+              callback(getError('Unable to create folder', dirPath))
+            }
+          }
+          const done = () => {
+            if (fileEntries.size === 0) {
+              callback()
+            }
+          }
+          for (const entry of fileEntries.values()) {
+            const entryName = pth.normalize(canonical(entry.entryName.toString()))
+            const filePath = sanitize(targetPath, entryName)
+            entry.getDataAsync(function (content, err_1) {
+              if (err_1) {
+                callback(new Error(err_1))
+                return
+              }
+              if (!content) {
+                callback(new Error(Utils.Errors.CANT_EXTRACT_FILE))
+              } else {
+                const fileAttr = keepOriginalPermission ? entry.header.fileAttr : void 0
+                filetools.writeFileToAsync(filePath, content, overwrite, fileAttr, function (succ) {
+                  if (!succ) {
+                    callback(getError('Unable to write file', filePath))
+                    return
+                  }
+                  filetools.fs.utimes(
+                    filePath,
+                    entry.header.time,
+                    entry.header.time,
+                    function (err_2) {
+                      if (err_2) {
+                        callback(getError('Unable to set times', filePath))
+                        return
+                      }
+                      fileEntries.delete(entry)
+                      done()
+                    }
+                  )
+                })
+              }
+            })
+          }
+          done()
+        },
+        writeZip: function (targetFileName, callback) {
+          if (arguments.length === 1) {
+            if (typeof targetFileName === 'function') {
+              callback = targetFileName
+              targetFileName = ''
+            }
+          }
+          if (!targetFileName && opts.filename) {
+            targetFileName = opts.filename
+          }
+          if (!targetFileName) return
+          var zipData = _zip.compressToBuffer()
+          if (zipData) {
+            var ok = filetools.writeFileTo(targetFileName, zipData, true)
+            if (typeof callback === 'function') callback(!ok ? new Error('failed') : null, '')
+          }
+        },
+        writeZipPromise: function (targetFileName, props) {
+          const { overwrite, perm } = Object.assign({ overwrite: true }, props)
+          return new Promise((resolve, reject) => {
+            if (!targetFileName && opts.filename) targetFileName = opts.filename
+            if (!targetFileName) reject('ADM-ZIP: ZIP File Name Missing')
+            this.toBufferPromise().then((zipData) => {
+              const ret = (done) =>
+                done ? resolve(done) : reject("ADM-ZIP: Wasn't able to write zip file")
+              filetools.writeFileToAsync(targetFileName, zipData, overwrite, perm, ret)
+            }, reject)
+          })
+        },
+        toBufferPromise: function () {
+          return new Promise((resolve, reject) => {
+            _zip.toAsyncBuffer(resolve, reject)
+          })
+        },
+        toBuffer: function (onSuccess, onFail, onItemStart, onItemEnd) {
+          this.valueOf = 2
+          if (typeof onSuccess === 'function') {
+            _zip.toAsyncBuffer(onSuccess, onFail, onItemStart, onItemEnd)
+            return null
+          }
+          return _zip.compressToBuffer()
+        },
+      }
+    }
   },
 })
 
@@ -7070,13 +9178,13 @@ function detect(ciEnvironment, env) {
 var src_default = detectCiEnvironment
 
 // src/publish.ts
-var import_fs = __toESM(require('fs'), 1)
+var import_fs2 = __toESM(require('fs'), 1)
 var import_http = __toESM(require('http'), 1)
 var import_https = __toESM(require('https'), 1)
-var import_path = require('path')
+var import_path2 = require('path')
 var import_stream = require('stream')
 var import_url = require('url')
-var import_util = require('util')
+var import_util2 = require('util')
 
 // src/manyglob.ts
 var import_fast_glob = __toESM(require_out4(), 1)
@@ -7100,8 +9208,52 @@ async function readStream(req) {
   return Buffer.concat(chunks)
 }
 
+// src/zipPaths.ts
+var import_adm_zip = __toESM(require_adm_zip(), 1)
+var import_fs = __toESM(require('fs'), 1)
+var os2 = __toESM(require('os'), 1)
+var import_path = require('path')
+var import_util = require('util')
+var readFile = (0, import_util.promisify)(import_fs.default.readFile)
+var writeFile = (0, import_util.promisify)(import_fs.default.writeFile)
+var mkdtemp = (0, import_util.promisify)(import_fs.default.mkdtemp)
+var realpath = (0, import_util.promisify)(import_fs.default.realpath)
+var rm = (0, import_util.promisify)(import_fs.default.rm)
+async function zipPaths(paths) {
+  const nonZips = paths.filter((path) => (0, import_path.extname)(path) !== '.zip')
+  const zips = paths.filter((path) => (0, import_path.extname)(path) === '.zip')
+  const admZip = new import_adm_zip.default()
+  for (const nonZip of nonZips) {
+    const content = await readFile(nonZip)
+    const name = (0, import_path.basename)(nonZip)
+    admZip.addFile(name, content)
+  }
+  const resultPaths = []
+  await withTempFile(
+    'one-report-publisher.zip',
+    (zipPath) => {
+      resultPaths.push(zipPath)
+      return writeFile(zipPath, admZip.toBuffer())
+    },
+    false
+  )
+  return resultPaths.concat(zips)
+}
+var withTempFile = (baseName, fn, remove) =>
+  withTempDir((dir) => fn((0, import_path.join)(dir, baseName)), remove)
+async function withTempDir(fn, remove) {
+  const dir = await mkdtemp((await realpath(os2.tmpdir())) + import_path.sep)
+  try {
+    await fn(dir)
+  } finally {
+    if (remove) {
+      await rm(dir, { recursive: true })
+    }
+  }
+}
+
 // src/publish.ts
-var lstat = (0, import_util.promisify)(import_fs.default.lstat)
+var lstat = (0, import_util2.promisify)(import_fs2.default.lstat)
 var extensions = ['.xml', '.json', '.ndjson', '.zip']
 var contentTypes = {
   '.xml': 'text/xml',
@@ -7109,7 +9261,7 @@ var contentTypes = {
   '.ndjson': 'application/x-ndjson',
   '.zip': 'application/zip',
 }
-async function publish(globs, organizationId, baseUrl, env, authenticate) {
+async function publish(globs, zip, organizationId, baseUrl, env, authenticate) {
   if (!Array.isArray(globs)) {
     throw new Error('globs must be an array')
   }
@@ -7123,12 +9275,13 @@ async function publish(globs, organizationId, baseUrl, env, authenticate) {
   )
   const ciEnv = src_default(env)
   const paths = (await manyglob(globs))
-    .filter((path) => extensions.includes((0, import_path.extname)(path)))
+    .filter((path) => extensions.includes((0, import_path2.extname)(path)))
     .sort()
   if (paths.length === 0) {
     throw new Error(`No report files found. Please check your globs: ${JSON.stringify(globs)}`)
   }
-  return Promise.all(paths.map((path) => publishFile(path, url, ciEnv, authHeaders)))
+  const publishPaths = zip ? await zipPaths(paths) : paths
+  return Promise.all(publishPaths.map((path) => publishFile(path, url, ciEnv, authHeaders)))
 }
 async function publishFile(path, url, ciEnv, authHeaders) {
   return new Promise((resolve, reject) => {
@@ -7146,7 +9299,7 @@ async function publishFile(path, url, ciEnv, authHeaders) {
             return reject(new Error(`Unsupported protocol: ${url.toString()}`))
         }
         const headers = {
-          'Content-Type': contentTypes[(0, import_path.extname)(path)],
+          'Content-Type': contentTypes[(0, import_path2.extname)(path)],
           'Content-Length': stat.size,
           ...(ciEnv?.git?.remote ? { 'OneReport-SourceControl': ciEnv.git.remote } : {}),
           ...(ciEnv?.git?.revision ? { 'OneReport-Revision': ciEnv.git.revision } : {}),
@@ -7188,7 +9341,7 @@ POST ${url.toString()} -d @${path}
           }
         )
         req.on('error', reject)
-        const file = import_fs.default.createReadStream(path)
+        const file = import_fs2.default.createReadStream(path)
         ;(0, import_stream.pipeline)(file, req, (err) => {
           try {
             if (err) return reject(err)
@@ -7234,8 +9387,10 @@ async function main() {
   const password = import_core.default.getInput('password')
   const globs = import_core.default.getMultilineInput('reports')
   const baseUrl = import_core.default.getInput('url')
+  const zip = import_core.default.getBooleanInput('zip')
   const responseBodies = await publish(
     globs,
+    zip,
     organizationId,
     baseUrl,
     process.env,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@cucumber/ci-environment": "9.0.0",
+        "@types/adm-zip": "0.4.34",
+        "adm-zip": "0.5.9",
         "commander": "8.3.0",
         "fast-glob": "3.2.11",
         "source-map-support": "0.5.21"
@@ -310,6 +312,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.4.34",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
+      "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -337,8 +347,7 @@
     "node_modules/@types/node": {
       "version": "17.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
-      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
-      "dev": true
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.10.1",
@@ -613,6 +622,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -6017,6 +6034,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/adm-zip": {
+      "version": "0.4.34",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
+      "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -6044,8 +6069,7 @@
     "@types/node": {
       "version": "17.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
-      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
-      "dev": true
+      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.10.1",
@@ -6205,6 +6229,11 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg=="
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
   },
   "dependencies": {
     "@cucumber/ci-environment": "9.0.0",
+    "@types/adm-zip": "0.4.34",
+    "adm-zip": "0.5.9",
     "commander": "8.3.0",
     "fast-glob": "3.2.11",
     "source-map-support": "0.5.21"

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -8,9 +8,11 @@ async function main() {
   const password = core.getInput('password')
   const globs = core.getMultilineInput('reports')
   const baseUrl = core.getInput('url')
+  const zip = core.getBooleanInput('zip')
 
   const responseBodies = await publish<OneReportResponseBody>(
     globs,
+    zip,
     organizationId,
     baseUrl,
     process.env,

--- a/src/bin/one-report-publisher.ts
+++ b/src/bin/one-report-publisher.ts
@@ -9,15 +9,15 @@ program.requiredOption('-o, --organization-id <id>', 'OneReport organization id'
 program.requiredOption('-p, --password <password>', 'OneReport password')
 program.requiredOption('-r, --reports <glob...>', 'Glob to the files to publish')
 program.option('-u, --url <url>', 'OneReport URL', 'https://one-report.vercel.app')
-program.option('-z, --zip', 'Zip non .zip files', true)
+program.option('--no-zip', 'Do not zip non .zip files', false)
 
 async function main() {
   program.parse(process.argv)
-  const { organizationId, password, reports: globs, url: baseUrl, zip } = program.opts()
+  const { organizationId, password, reports: globs, url: baseUrl, zip: noZip } = program.opts()
 
   const responseBodies = await publish<OneReportResponseBody>(
     globs,
-    zip,
+    !noZip,
     organizationId,
     baseUrl,
     process.env,

--- a/src/bin/one-report-publisher.ts
+++ b/src/bin/one-report-publisher.ts
@@ -13,7 +13,7 @@ program.option('--no-zip', 'Do not zip non .zip files', false)
 
 async function main() {
   program.parse(process.argv)
-  const { organizationId, password, reports: globs, url: baseUrl, zip: noZip } = program.opts()
+  const { organizationId, password, reports: globs, url: baseUrl, noZip } = program.opts()
 
   const responseBodies = await publish<OneReportResponseBody>(
     globs,

--- a/src/bin/one-report-publisher.ts
+++ b/src/bin/one-report-publisher.ts
@@ -9,13 +9,15 @@ program.requiredOption('-o, --organization-id <id>', 'OneReport organization id'
 program.requiredOption('-p, --password <password>', 'OneReport password')
 program.requiredOption('-r, --reports <glob...>', 'Glob to the files to publish')
 program.option('-u, --url <url>', 'OneReport URL', 'https://one-report.vercel.app')
+program.option('-z, --zip', 'Zip non .zip files', true)
 
 async function main() {
   program.parse(process.argv)
-  const { organizationId, password, reports: globs, url: baseUrl } = program.opts()
+  const { organizationId, password, reports: globs, url: baseUrl, zip } = program.opts()
 
   const responseBodies = await publish<OneReportResponseBody>(
     globs,
+    zip,
     organizationId,
     baseUrl,
     process.env,

--- a/src/zipPaths.ts
+++ b/src/zipPaths.ts
@@ -1,0 +1,51 @@
+import AdmZip from 'adm-zip'
+import fs from 'fs'
+import * as os from 'os'
+import { basename, extname, join, sep } from 'path'
+import { promisify } from 'util'
+
+const readFile = promisify(fs.readFile)
+const writeFile = promisify(fs.writeFile)
+const mkdtemp = promisify(fs.mkdtemp)
+const realpath = promisify(fs.realpath)
+const rm = promisify(fs.rm)
+
+export async function zipPaths(paths: readonly string[]): Promise<readonly string[]> {
+  const nonZips = paths.filter((path) => extname(path) !== '.zip')
+  const zips = paths.filter((path) => extname(path) === '.zip')
+
+  const admZip = new AdmZip()
+
+  for (const nonZip of nonZips) {
+    const content = await readFile(nonZip)
+    const name = basename(nonZip)
+    // Not using zip.addLocalFile because it is synchronous
+    admZip.addFile(name, content)
+  }
+  const resultPaths: string[] = []
+  await withTempFile(
+    'one-report-publisher.zip',
+    (zipPath) => {
+      resultPaths.push(zipPath)
+      return writeFile(zipPath, admZip.toBuffer())
+    },
+    false
+  )
+  return resultPaths.concat(zips)
+}
+
+// https://advancedweb.hu/secure-tempfiles-in-nodejs-without-dependencies/
+
+const withTempFile = (baseName: string, fn: (fileName: string) => Promise<void>, remove: boolean) =>
+  withTempDir((dir) => fn(join(dir, baseName)), remove)
+
+async function withTempDir(fn: (dirName: string) => Promise<void>, remove: boolean) {
+  const dir = await mkdtemp((await realpath(os.tmpdir())) + sep)
+  try {
+    await fn(dir)
+  } finally {
+    if (remove) {
+      await rm(dir, { recursive: true })
+    }
+  }
+}

--- a/test/oneReportPublishTest.ts
+++ b/test/oneReportPublishTest.ts
@@ -20,6 +20,7 @@ describe('oneReportPublish', () => {
     const baseUrl = `https://one-report.vercel.app`
     const responseBodies = await publish<OneReportResponseBody>(
       ['test/fixtures/*.{xml,json}'],
+      true,
       process.env.ONE_REPORT_TEST_ORGANIZATION_ID,
       baseUrl,
       process.env,

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -62,7 +62,7 @@ describe('publish', () => {
     })
   })
 
-  it('publishes files from glob', async () => {
+  it('publishes files from glob without zipping', async () => {
     const organizationId = '32C46057-0AB6-44E8-8944-0246E0BEA96F'
 
     const fakeEnv: Env = {
@@ -135,9 +135,6 @@ describe('publish', () => {
         body: await readFile('test/fixtures/bundled.zip'),
       },
     ]
-    // Requests are sent in parallel, so we don't know what request hit the server first.
-    const sortByContentType = (a: ServerRequest, b: ServerRequest) =>
-      a.headers['content-type']!.localeCompare(b.headers['content-type']!)
     const sortedServerRequests = serverRequests.sort(sortByContentType)
     const sortedExpectedServerRequests = expectedServerRequests.sort(sortByContentType)
 
@@ -160,4 +157,66 @@ describe('publish', () => {
 
     assert.deepStrictEqual(responseBodies, expectedResponseBodies)
   })
+
+  it('publishes files from glob with zipping', async () => {
+    const organizationId = '32C46057-0AB6-44E8-8944-0246E0BEA96F'
+
+    const fakeEnv: Env = {}
+
+    const responseBodies = await publish<TestResponseBody>(
+      ['test/fixtures/*.{xml,json,ndjson,zip}'],
+      true,
+      organizationId,
+      `http://localhost:${port}`,
+      fakeEnv,
+      () => Promise.resolve({})
+    )
+    const expectedServerRequests: Omit<ServerRequest, 'body'>[] = [
+      {
+        url: `/api/organization/${organizationId}/execution`,
+        headers: {
+          'content-type': 'application/zip',
+          connection: 'close',
+          host: `localhost:${port}`,
+        },
+      },
+      {
+        url: `/api/organization/${organizationId}/execution`,
+        headers: {
+          'content-type': 'application/zip',
+          connection: 'close',
+          host: `localhost:${port}`,
+        },
+      },
+    ]
+    const sortedServerRequests: Omit<ServerRequest, 'body'>[] = serverRequests
+      .sort(sortByContentType)
+      .map((req) => {
+        const headers = JSON.parse(JSON.stringify(req.headers))
+        delete headers['content-length']
+        return {
+          url: req.url,
+          headers,
+        }
+      })
+    const sortedExpectedServerRequests = expectedServerRequests.sort(sortByContentType)
+
+    assert.deepStrictEqual(sortedServerRequests, sortedExpectedServerRequests)
+
+    const expectedResponseBodies: TestResponseBody[] = [
+      {
+        hello: 'world',
+      },
+      {
+        hello: 'world',
+      },
+    ]
+
+    assert.deepStrictEqual(responseBodies, expectedResponseBodies)
+  })
 })
+
+// Requests are sent in parallel, so we don't know what request hit the server first.
+function sortByContentType(a: ServerRequest, b: ServerRequest) {
+  return a.headers['content-type']!.localeCompare(b.headers['content-type']!)
+}

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -75,6 +75,7 @@ describe('publish', () => {
 
     const responseBodies = await publish<TestResponseBody>(
       ['test/fixtures/*.{xml,json,ndjson,zip}'],
+      false,
       organizationId,
       `http://localhost:${port}`,
       fakeEnv,

--- a/test/zipPaths.test.ts
+++ b/test/zipPaths.test.ts
@@ -9,7 +9,7 @@ import { manyglob } from '../src/manyglob.js'
 import { zipPaths } from '../src/zipPaths.js'
 const readFile = promisify(fs.readFile)
 
-describe('zip', () => {
+describe('zipPaths', () => {
   it('zips non .zip files into a temporary file', async () => {
     const paths = (await manyglob(['test/fixtures/*.{zip,ndjson,json,xml}'])).slice().sort()
     const zippedPaths = await zipPaths(paths)

--- a/test/zipPaths.test.ts
+++ b/test/zipPaths.test.ts
@@ -1,0 +1,32 @@
+// import { extname } from 'path'
+import AdmZip from 'adm-zip'
+import assert from 'assert'
+import fs from 'fs'
+import { basename, extname } from 'path'
+import { promisify } from 'util'
+
+import { manyglob } from '../src/manyglob.js'
+import { zipPaths } from '../src/zipPaths.js'
+const readFile = promisify(fs.readFile)
+
+describe('zip', () => {
+  it('zips non .zip files into a temporary file', async () => {
+    const paths = (await manyglob(['test/fixtures/*.{zip,ndjson,json,xml}'])).slice().sort()
+    const zippedPaths = await zipPaths(paths)
+    assert.strictEqual(zippedPaths.length, 2)
+
+    const generatedZipPath = zippedPaths[0]
+    const admZip = new AdmZip(await readFile(generatedZipPath))
+    const entryNames = admZip
+      .getEntries()
+      .map((entry) => entry.entryName)
+      .sort()
+
+    const expected = paths
+      .filter((path) => extname(path) !== '.zip')
+      .map((path) => basename(path))
+      .sort()
+
+    assert.deepStrictEqual(entryNames, expected)
+  })
+})


### PR DESCRIPTION
This change will zip all files in the glob by default (excluding files that are already `.zip`) and send them in a single request.

This causes OneReport to treat them as a single execution rather than one execution per file. This is useful in conjunction with e.g. [Maven surefire](https://maven.apache.org/surefire/maven-surefire-plugin/), which produces one `.xml` file for each JUnit class.