### PR TITLE
Add options for timeout and ignoring error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new `--max-time <seconds>` option
+- Add new `--ignore-error` option
+
 ## [0.2.0] - 2022-02-07
 
 ### Added

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,12 @@ inputs:
   reports:
     description: 'Globs to the files to publish'
     required: true
+  max-time:
+    description: 'Max time for each request'
+    required: false
+  ignore-error:
+    description: 'Exit with 0 even if a timeout or error occurred'
+    required: false
   url:
     description: 'OneReport URL'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,7 @@ inputs:
   ignore-error:
     description: 'Exit with 0 even if a timeout or error occurred'
     required: false
+    default: 'false'
   url:
     description: 'OneReport URL'
     required: false

--- a/src/action/index.ts
+++ b/src/action/index.ts
@@ -3,21 +3,25 @@ import { URL } from 'url'
 
 import { basicAuthAuthenticator, OneReportResponseBody, publish } from '../../src/index.js'
 
-async function main() {
-  const organizationId = core.getInput('organization-id')
-  const username = core.getInput('username')
-  const password = core.getInput('password')
-  const globs = core.getMultilineInput('reports')
-  const baseUrl = core.getInput('url')
-  const zip = core.getBooleanInput('zip')
+const organizationId = core.getInput('organization-id')
+const username = core.getInput('username')
+const password = core.getInput('password')
+const globs = core.getMultilineInput('reports')
+const maxTime = core.getInput('max-time')
+const ignoreError = core.getBooleanInput('ignore-error')
+const baseUrl = core.getInput('url')
+const zip = core.getBooleanInput('zip')
 
+async function main() {
+  const requestTimeout = maxTime ? +maxTime * 1000 : undefined
   const responseBodies = await publish<OneReportResponseBody>(
     globs,
     zip,
     organizationId,
     baseUrl,
     process.env,
-    basicAuthAuthenticator(username, password)
+    basicAuthAuthenticator(username, password),
+    requestTimeout
   )
 
   return responseBodies.map((body) =>
@@ -40,4 +44,10 @@ main()
     }
     core.endGroup()
   })
-  .catch((error) => core.setFailed(error.message))
+  .catch((error) => {
+    if (ignoreError) {
+      core.info(error.message)
+    } else {
+      core.setFailed(error.message)
+    }
+  })

--- a/src/bin/one-report-publisher.ts
+++ b/src/bin/one-report-publisher.ts
@@ -9,20 +9,33 @@ program.requiredOption('-o, --organization-id <id>', 'OneReport organization id'
 program.requiredOption('-u, --username <username>', 'OneReport username')
 program.requiredOption('-p, --password <password>', 'OneReport password')
 program.requiredOption('-r, --reports <glob...>', 'Glob to the files to publish')
+program.option('-m, --max-time <seconds>', 'Max time for each request')
+program.option('-i, --ignore-error', 'Exit with 0 even if a timeout or error occurred')
 program.option('--url <url>', 'OneReport URL', 'https://one-report.vercel.app')
 program.option('--no-zip', 'Do not zip non .zip files', false)
 
-async function main() {
-  program.parse(process.argv)
-  const { organizationId, username, password, reports: globs, url: baseUrl, noZip } = program.opts()
+program.parse(process.argv)
+const {
+  organizationId,
+  username,
+  password,
+  reports: globs,
+  maxTime,
+  ignoreError,
+  url: baseUrl,
+  noZip,
+} = program.opts()
 
+async function main() {
+  const requestTimeout = maxTime ? +maxTime * 1000 : undefined
   const responseBodies = await publish<OneReportResponseBody>(
     globs,
     !noZip,
     organizationId,
     baseUrl,
     process.env,
-    basicAuthAuthenticator(username, password)
+    basicAuthAuthenticator(username, password),
+    requestTimeout
   )
 
   return responseBodies.map((body) =>
@@ -42,5 +55,9 @@ main()
   })
   .catch((error) => {
     console.error(error.stack)
-    process.exit(1)
+    if (ignoreError) {
+      process.exit(0)
+    } else {
+      process.exit(1)
+    }
   })

--- a/test/oneReportPublishTest.ts
+++ b/test/oneReportPublishTest.ts
@@ -24,7 +24,8 @@ describe('oneReportPublish', () => {
       process.env.ONE_REPORT_TEST_ORGANIZATION_ID,
       baseUrl,
       process.env,
-      basicAuthAuthenticator('anyone', process.env.ONE_REPORT_PASSWORD)
+      basicAuthAuthenticator('anyone', process.env.ONE_REPORT_PASSWORD),
+      undefined
     )
 
     assert.strictEqual(responseBodies.length, 2)


### PR DESCRIPTION
The `--ignore-error` option is useful for not failing the build if the server has high latency and we want to avoid failing CI builds.

The `--max-time` option is useful for limiting how long we want to wait (for faster builds)